### PR TITLE
mrc-4337 support source cloning

### DIFF
--- a/config/basic/packit.yml
+++ b/config/basic/packit.yml
@@ -28,7 +28,7 @@ volumes:
 
 outpack:
   initial:
-    source: demo
+    url: https://github.com/reside-ic/orderly3-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -27,8 +27,9 @@ volumes:
   proxy_logs: packit_proxy_logs
 
 outpack:
+  ## Initialise an empty outpack directory by cloning from github
   initial:
-    source: demo
+    url: https://github.com/reside-ic/orderly3-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/noproxy/packit.yml
+++ b/config/noproxy/packit.yml
@@ -24,7 +24,7 @@ volumes:
 
 outpack:
   initial:
-    source: demo
+    url: https://github.com/reside-ic/orderly3-example.git
   server:
     name: outpack_server
     tag: main

--- a/src/packit_deploy/__about__.py
+++ b/src/packit_deploy/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Alex Hill <alex.hill@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/src/packit_deploy/config.py
+++ b/src/packit_deploy/config.py
@@ -17,18 +17,8 @@ class PackitConfig:
         self.repo = config.config_string(dat, ["repo"])
 
         if "initial" in dat["outpack"]:
-            source = config.config_string(dat, ["outpack", "initial", "source"])
-            if source == "demo":
-                self.outpack_demo = True
-                self.outpack_source_url = None
-            elif source == "clone":
-                self.outpack_demo = False
-                self.outpack_source_url = config.config_string(dat, ["outpack", "initial", "url"])
-            else:
-                err = "Unknown outpack initial source. Valid values are 'demo' and 'clone'"
-                raise Exception(err)
+            self.outpack_source_url = config.config_string(dat, ["outpack", "initial", "url"])
         else:
-            self.outpack_demo = False
             self.outpack_source_url = None
 
         self.outpack_ref = self.build_ref(dat, "outpack", "server")

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -50,10 +50,7 @@ def outpack_init_clone(cfg):
 
     url = cfg.outpack_source_url
     with DockerClient() as cl:
-        cl.containers.run(
-            image, mounts=[outpack], remove=True,
-            entrypoint=["git", "clone", url, "/outpack"]
-        )
+        cl.containers.run(image, mounts=[outpack], remove=True, entrypoint=["git", "clone", url, "/outpack"])
 
     if not outpack_is_initialised(cfg):
         image = "mrcide/outpack.orderly:main"
@@ -61,8 +58,7 @@ def outpack_init_clone(cfg):
 
         with DockerClient() as cl:
             cl.containers.run(
-                image, mounts=[mount], remove=True,
-                entrypoint=["R", "-e", "outpack::outpack_init('/outpack')"]
+                image, mounts=[mount], remove=True, entrypoint=["R", "-e", "outpack::outpack_init('/outpack')"]
             )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def test_parse_args():
 
 def test_version():
     res = cli.main(["--version"])
-    assert res == "0.0.7"
+    assert res == "0.0.8"
 
 
 def test_args_passed_to_start():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,8 +21,7 @@ def test_config_no_proxy():
     assert str(cfg.images["packit-db"]) == "mrcide/packit-db:main"
     assert str(cfg.images["packit-api"]) == "mrcide/packit-api:main"
 
-    assert cfg.outpack_demo is True
-    assert cfg.outpack_source_url is None
+    assert cfg.outpack_source_url is not None
     assert cfg.proxy_enabled is False
     assert cfg.protect_data is False
 
@@ -54,16 +53,8 @@ def test_config_proxy():
 
 
 def test_outpack_initial_source():
-    options = {"outpack": {"initial": {"source": "wrong"}}}
-    with pytest.raises(Exception) as err:
-        PackitConfig("config/noproxy", options=options)
-    assert str(err.value) == "Unknown outpack initial source. Valid values are 'demo' and 'clone'"
-
-    options = {"outpack": {"initial": {"source": "clone", "url": "whatever"}}}
-    cfg = PackitConfig("config/noproxy", options=options)
-    assert cfg.outpack_demo is False
-    assert cfg.outpack_source_url == "whatever"
+    cfg = PackitConfig("config/complete")
+    assert cfg.outpack_source_url == "https://github.com/reside-ic/orderly3-example.git"
 
     cfg = PackitConfig("config/nodemo")
-    assert cfg.outpack_demo is False
     assert cfg.outpack_source_url is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-import pytest
-
 from src.packit_deploy.config import PackitConfig
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,20 +85,17 @@ def test_proxy_ssl_configured():
     try:
         with vault_dev.server() as s:
             url = f"http://localhost:{s.port}"
-            cfg = PackitConfig(path, options={
-                "vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
+            cfg = PackitConfig(path, options={"vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
             cl = cfg.vault.client()
             cl.write("secret/cert", value="c3rt")
             cl.write("secret/key", value="s3cret")
             cl.write("secret/db/user", value="us3r")
             cl.write("secret/db/password", value="p@ssword")
 
-            cli.main(["start", path, f"--option=vault.addr={url}",
-                      f"--option=vault.auth.args.token={s.token}"])
+            cli.main(["start", path, f"--option=vault.addr={url}", f"--option=vault.auth.args.token={s.token}"])
 
             proxy = cfg.get_container("proxy")
-            cert = docker_util.string_from_container(proxy,
-                                                     "run/proxy/certificate.pem")
+            cert = docker_util.string_from_container(proxy, "run/proxy/certificate.pem")
             key = docker_util.string_from_container(proxy, "run/proxy/key.pem")
             assert "c3rt" in cert
             assert "s3cret" in key
@@ -119,9 +116,7 @@ def test_api_configured():
         cfg = PackitConfig(path)
 
         api = cfg.get_container("packit-api")
-        api_config = docker_util.string_from_container(api,
-                                                       "/etc/packit/config.properties").split(
-            "\n")
+        api_config = docker_util.string_from_container(api, "/etc/packit/config.properties").split("\n")
 
         assert "db.url=jdbc:postgresql://packit-packit-db:5432/packit?stringtype=unspecified" in api_config
         assert "db.user=packituser" in api_config
@@ -138,14 +133,11 @@ def test_outpack_already_initialised():
     path = "config/noproxy"
     outpack_vol = docker.types.Mount("/outpack", "outpack_volume")
     with DockerClient() as cl:
-        cl.containers.run("ubuntu", remove=True, mounts=[outpack_vol],
-                          command=["mkdir", "/outpack/.outpack"])
+        cl.containers.run("ubuntu", remove=True, mounts=[outpack_vol], command=["mkdir", "/outpack/.outpack"])
         cl.containers.run(
-            "ubuntu", remove=True, mounts=[outpack_vol],
-            command=["touch", "/outpack/.outpack/config.json"]
+            "ubuntu", remove=True, mounts=[outpack_vol], command=["touch", "/outpack/.outpack/config.json"]
         )
-        cl.containers.run("ubuntu", remove=True, mounts=[outpack_vol],
-                          command=["mkdir", "/outpack/.outpack/test.txt"])
+        cl.containers.run("ubuntu", remove=True, mounts=[outpack_vol], command=["mkdir", "/outpack/.outpack/test.txt"])
     try:
         cli.main(["start", path])
     finally:
@@ -159,21 +151,17 @@ def test_vault():
     try:
         with vault_dev.server() as s:
             url = f"http://localhost:{s.port}"
-            cfg = PackitConfig(path, options={
-                "vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
+            cfg = PackitConfig(path, options={"vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
             cl = cfg.vault.client()
             cl.write("secret/cert", value="c3rt")
             cl.write("secret/key", value="s3cret")
             cl.write("secret/db/user", value="us3r")
             cl.write("secret/db/password", value="p@ssword")
 
-            cli.main(["start", path, f"--option=vault.addr={url}",
-                      f"--option=vault.auth.args.token={s.token}"])
+            cli.main(["start", path, f"--option=vault.addr={url}", f"--option=vault.auth.args.token={s.token}"])
 
             api = cfg.get_container("packit-api")
-            api_config = docker_util.string_from_container(api,
-                                                           "/etc/packit/config.properties").split(
-                "\n")
+            api_config = docker_util.string_from_container(api, "/etc/packit/config.properties").split("\n")
 
             assert "db.user=us3r" in api_config
             assert "db.password=p@ssword" in api_config


### PR DESCRIPTION
This implements the functionality to clone an outpack (in practice, orderly) source repo. I've removed the "demo" option, since in practice the way to achieve this is just to set the cloned source url to our publicly available demo repo: https://github.com/reside-ic/orderly3-example.