### PR TITLE
Use hard-coded email and password when creating the super user

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,5 @@ You will need access to the vault to run the `githubauth` configuration, which r
 details.
 
 ### Notes
-1. If running app in **basic auth** mode, a super admin user can be created by running `./scripts/create-super-user.sh` after the app is running.
+
+If developing in **basic auth** mode, a super admin user can be created by running `./scripts/create-super-user.sh` after the app is running.

--- a/scripts/create-super-user
+++ b/scripts/create-super-user
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-# FOR BASIC AUTH ONLY!!! 
-ADMIN_EMAIL=$(vault read -field=superUserEmail secret/packit/basicauth)
-ADMIN_PASSWORD_ENCODED=$(vault read -field=superUserEncodedPassword secret/packit/basicauth)
-ADMIN_UUID=$(vault read -field=superAdminUUID secret/packit/basicauth)
+# This is a super user account, intended for local development / testing only.
+# The password is "password".
+# Ensure api has ran and tables and initial data have been created.
+ADMIN_EMAIL='resideUser@resideAdmin.ic.ac.uk'
+ADMIN_PASSWORD_ENCODED='$2y$10$snpZ8bgdkh2hy8lDtyHF7ejD5.K1vsMqaFteCkmBhdBQj3JTlJRM6'
+ADMIN_UUID='2754daf8-fea0-4bf4-af60-810764f24d71'
 
-docker exec packit-packit-db create-super-user --email $ADMIN_EMAIL --password $ADMIN_PASSWORD_ENCODED --uuid $ADMIN_UUID
+docker exec packit-packit-db create-super-user --email "$ADMIN_EMAIL" --password "$ADMIN_PASSWORD_ENCODED" --uuid "$ADMIN_UUID"


### PR DESCRIPTION
Bringing this file up-to-date with the following change in mrc-ide/packit: https://github.com/mrc-ide/packit/commit/5091cef0fbc442925582547f516ad040eb383c9a

I needed to make this change in order to log in, so perhaps the vault secrets are encrypting a different password (which I don't know what it is).