### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -77,7 +77,7 @@ packit:
     oauth2:
       redirect:
         # Root url which OAuth2 app will use to redirect back to packit api - must match OAuth2 app's registered url
-        packit_api_root: "https://packit/packit/api"
+        packit_api_root: "https://packit/api"
         url: "https://packit/redirect"  # Url for redirecting back to the front end after successful authentication
 
 ## If running a proxy directly, fill this section in.  Otherwise you

--- a/config/githubauth/packit.yml
+++ b/config/githubauth/packit.yml
@@ -70,7 +70,7 @@ packit:
     oauth2:
       redirect:
         # Root url which OAuth2 app will be requested to use to redirect back to packit api - must match root of OAuth2 app's registered url
-        packit_api_root: "https://localhost/packit/api"
+        packit_api_root: "https://localhost/api"
         url: "https://localhost/redirect" # Url for redirecting back to the front end after successful authentication
 
 ## If running a proxy directly, fill this section in.  Otherwise you

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,5 +78,5 @@ def test_github_auth():
     assert cfg.packit_auth_github_client_id == "VAULT:secret/packit/githubauth/auth/githubclient:id"
     assert cfg.packit_auth_github_client_secret == "VAULT:secret/packit/githubauth/auth/githubclient:secret"
     assert cfg.packit_auth_jwt_secret == "VAULT:secret/packit/githubauth/auth/jwt:secret"
-    assert cfg.packit_auth_oauth2_redirect_packit_api_root == "https://localhost/packit/api"
+    assert cfg.packit_auth_oauth2_redirect_packit_api_root == "https://localhost/api"
     assert cfg.packit_auth_oauth2_redirect_url == "https://localhost/redirect"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,11 +68,11 @@ def test_start_and_stop_proxy():
         ports = proxy.attrs["HostConfig"]["PortBindings"]
         assert set(ports.keys()) == {"443/tcp", "80/tcp"}
         http_get("http://localhost")
-        res = http_get("http://localhost/packit/api/packets", poll=3)
+        res = http_get("http://localhost/api/packets", poll=3)
         # might take some seconds for packets to appear
         retries = 1
         while len(json.loads(res)) < 1 and retries < 5:
-            res = http_get("http://localhost/packit/api/packets")
+            res = http_get("http://localhost/api/packets")
             time.sleep(5)
             retries = retries + 1
         assert len(json.loads(res)) > 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,7 +83,7 @@ def test_start_and_stop_proxy():
 def test_proxy_ssl_configured():
     path = "config/complete"
     try:
-        with vault_dev.server() as s:
+        with vault_dev.Server() as s:
             url = f"http://localhost:{s.port}"
             cfg = PackitConfig(path, options={"vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
             write_secrets_to_vault(cfg)
@@ -126,7 +126,7 @@ def test_api_configured():
 def test_api_configured_for_github_auth():
     path = "config/complete"
     try:
-        with vault_dev.server() as s:
+        with vault_dev.Server() as s:
             url = f"http://localhost:{s.port}"
             cfg = PackitConfig(path, options={"vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
             write_secrets_to_vault(cfg)
@@ -150,7 +150,7 @@ def test_api_configured_for_github_auth():
 def test_vault():
     path = "config/complete"
     try:
-        with vault_dev.server() as s:
+        with vault_dev.Server() as s:
             url = f"http://localhost:{s.port}"
             cfg = PackitConfig(path, options={"vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
             write_secrets_to_vault(cfg)
@@ -168,7 +168,7 @@ def test_vault():
 def test_ssh():
     path = "config/complete"
     try:
-        with vault_dev.server() as s:
+        with vault_dev.Server() as s:
             url = f"http://localhost:{s.port}"
             cfg = PackitConfig(path, options={"vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
             write_secrets_to_vault(cfg)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,7 +54,7 @@ def test_status():
 def test_start_and_stop_proxy():
     path = "config/novault"
     try:
-        res = cli.main(["start", path])
+        res = cli.main(["start", "--pull", path])
         assert res
 
         cl = docker.client.from_env()


### PR DESCRIPTION
After merging #13, the build is broken on `master`, after a successful build of the PR; this is because the proxy changed and because we use the `main` branch of that in the tests.  So our integration test was hitting the *old* proxy configuration on the branch and successfully hitting the api, but once we merged `master` in this started failing because the test needed the path changed.

I've also searched for other appearances of `packit/api` and fixed those that are a problem. There's also a set of deprecation warnings fixed in `vault_dev`, to go along with the ones that were fixed previously.

I also changed the matrix strategy to disable fail-fast, because this makes restarting failed builds really annoying. Most of our builds work with `fail-fast: false`