### PR TITLE
Add support for workers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,15 +29,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Pull containers
-        run: |
-          docker pull redis:8.0
-          docker pull mrcide/outpack.orderly:main
-          docker pull mrcide/outpack_server:main
-          docker pull mrcide/packit-db:main
-          docker pull mrcide/packit-api:main
-          docker pull mrcide/packit:main
-          docker pull mrcide/packit-proxy:main
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Pull containers
         run: |
-          docker pull redis:5.0
+          docker pull redis:8.0
           docker pull mrcide/outpack.orderly:main
           docker pull mrcide/outpack_server:main
           docker pull mrcide/packit-db:main

--- a/config/basicauth/packit.yml
+++ b/config/basicauth/packit.yml
@@ -31,7 +31,7 @@ outpack:
   initial:
     ##  If using a private repo, then use an ssh url and provide ssh keys in the
     ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly3-example.git
+    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -93,7 +93,7 @@ orderly-runner:
     name: orderly.runner
     tag: main
   git:
-    url: https://github.com/reside-ic/orderly3-example.git
+    url: https://github.com/reside-ic/orderly2-example.git
   workers: 1
 
 

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -34,11 +34,6 @@ ssh:
   private: VAULT:secret/ssh:private
 
 outpack:
-  ## Initialise an outpack directory by cloning from github
-  initial:
-    ##  If using a private repo, then use an ssh url and provide ssh keys in the
-    ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly3-example.git
   server:
     name: outpack_server
     tag: main
@@ -81,10 +76,21 @@ packit:
         url: "https://packit/redirect"  # Url for redirecting back to the front end after successful authentication
 
 orderly-runner:
+  # The image for the runner; this is going to be a trick because the
+  # image needs to contain at least the runner itself (a container
+  # that we create that contains the packages required to actually run
+  # the queue) and the packages that the user needs to run their
+  # reports.  The latter we might change to use a volume later, which
+  # has the advantage of all runners definitely seeing the same data,
+  # even in the case where we update/change/install packages without
+  # redeploying.
   image:
     name: orderly.runner
     tag: main
+  git:
+    url: https://github.com/reside-ic/orderly3-example.git
   workers: 1
+
 
 ## If running a proxy directly, fill this section in.  Otherwise you
 ## are responsible for proxying the application out of the docker

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -80,6 +80,12 @@ packit:
         packit_api_root: "https://packit/api"
         url: "https://packit/redirect"  # Url for redirecting back to the front end after successful authentication
 
+orderly-runner:
+  image:
+    name: orderly.runner
+    tag: main
+  workers: 1
+
 ## If running a proxy directly, fill this section in.  Otherwise you
 ## are responsible for proxying the application out of the docker
 ## network

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -25,6 +25,8 @@ network: packit-network
 volumes:
   outpack: outpack_volume
   proxy_logs: packit_proxy_logs
+  orderly_library: orderly_library
+  orderly_logs: orderly_logs
 
 ## Path to ssh key for interacting with git. You
 ## might use a github deploy key here. For completeness both the

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -83,14 +83,6 @@ packit:
         url: "https://packit/redirect"  # Url for redirecting back to the front end after successful authentication
 
 orderly-runner:
-  # The image for the runner; this is going to be a trick because the
-  # image needs to contain at least the runner itself (a container
-  # that we create that contains the packages required to actually run
-  # the queue) and the packages that the user needs to run their
-  # reports.  The latter we might change to use a volume later, which
-  # has the advantage of all runners definitely seeing the same data,
-  # even in the case where we update/change/install packages without
-  # redeploying.
   image:
     name: orderly.runner
     tag: main

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -34,6 +34,11 @@ ssh:
   private: VAULT:secret/ssh:private
 
 outpack:
+  ## Initialise an outpack directory by cloning from github
+  initial:
+    ##  If using a private repo, then use an ssh url and provide ssh keys in the
+    ## "ssh" section above.
+    url: https://github.com/reside-ic/orderly3-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -38,7 +38,7 @@ outpack:
   initial:
     ##  If using a private repo, then use an ssh url and provide ssh keys in the
     ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly3-example.git
+    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/githubauth/packit.yml
+++ b/config/githubauth/packit.yml
@@ -31,7 +31,7 @@ outpack:
   initial:
     ##  If using a private repo, then use an ssh url and provide ssh keys in the
     ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly3-example.git
+    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/noproxy/packit.yml
+++ b/config/noproxy/packit.yml
@@ -24,7 +24,7 @@ volumes:
 
 outpack:
   initial:
-    url: https://github.com/reside-ic/orderly3-example.git
+    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/novault/packit.yml
+++ b/config/novault/packit.yml
@@ -28,7 +28,7 @@ volumes:
 
 outpack:
   initial:
-    url: https://github.com/reside-ic/orderly3-example.git
+    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/runner/packit.yml
+++ b/config/runner/packit.yml
@@ -60,14 +60,6 @@ packit:
       secret: "0b4g4f8z4mdsrhoxfde2mam8f00vmt0f"
 
 orderly-runner:
-  # The image for the runner; this is going to be a trick because the
-  # image needs to contain at least the runner itself (a container
-  # that we create that contains the packages required to actually run
-  # the queue) and the packages that the user needs to run their
-  # reports.  The latter we might change to use a volume later, which
-  # has the advantage of all runners definitely seeing the same data,
-  # even in the case where we update/change/install packages without
-  # redeploying.
   image:
     name: orderly.runner
     tag: main

--- a/config/runner/packit.yml
+++ b/config/runner/packit.yml
@@ -1,0 +1,86 @@
+## The name of the docker network that containers will be attached to.
+## If you want to proxy Packit to the host, you will need to
+## arrange a proxy on this network, or use dev_mode in the web section
+## below.
+## Prefix for container names; we'll use {container_prefix}-(container_name)
+container_prefix: packit
+
+## Set this flag to true to prevent use of --volumes in the cli to remove
+## volumes on stop
+protect_data: false
+
+## Docker org for images
+repo: mrcide
+
+## The name of the docker network that containers will be attached to.
+## If you want to proxy Packit to the host, you will need to
+## arrange a proxy on this network
+network: packit-network
+
+## Names of the docker volumes to use:
+##
+## outpack: stores the outpack metadata
+## proxy_logs: stores logs from the reverse proxy (only used if proxy is given)
+## (More volumes are anticipated as the tool develops)
+volumes:
+  outpack: outpack_volume
+  proxy_logs: packit_proxy_logs
+
+outpack:
+  ## Initialise an outpack directory by cloning from github
+  initial:
+    ##  If using a private repo, then use an ssh url and provide ssh keys in the
+    ## "ssh" section above.
+    url: https://github.com/reside-ic/orderly3-example.git
+  server:
+    name: outpack_server
+    tag: main
+  migrate:
+    name: outpack.orderly
+    tag: main
+packit:
+  api:
+    name: packit-api
+    tag: main
+  app:
+    name: packit
+    tag: main
+  db:
+    name: packit-db
+    tag: main
+    user: packituser
+    password: changeme
+  auth:
+    enabled: true
+    auth_method: basic
+    expiry_days: 1
+    jwt:
+      secret: "0b4g4f8z4mdsrhoxfde2mam8f00vmt0f"
+
+orderly-runner:
+  # The image for the runner; this is going to be a trick because the
+  # image needs to contain at least the runner itself (a container
+  # that we create that contains the packages required to actually run
+  # the queue) and the packages that the user needs to run their
+  # reports.  The latter we might change to use a volume later, which
+  # has the advantage of all runners definitely seeing the same data,
+  # even in the case where we update/change/install packages without
+  # redeploying.
+  image:
+    name: orderly.runner
+    tag: main
+  git:
+    url: https://github.com/reside-ic/orderly3-example.git
+  workers: 2
+
+## If running a proxy directly, fill this section in.  Otherwise you
+## are responsible for proxying the application out of the docker
+## network
+proxy:
+  enabled: true
+  hostname: localhost
+  port_http: 80
+  port_https: 443
+  image:
+    name: packit-proxy
+    tag: main

--- a/config/runner/packit.yml
+++ b/config/runner/packit.yml
@@ -25,6 +25,8 @@ network: packit-network
 volumes:
   outpack: outpack_volume
   proxy_logs: packit_proxy_logs
+  orderly_library: orderly_library
+  orderly_logs: orderly_logs
 
 outpack:
   ## Initialise an outpack directory by cloning from github

--- a/config/runner/packit.yml
+++ b/config/runner/packit.yml
@@ -31,7 +31,7 @@ outpack:
   initial:
     ##  If using a private repo, then use an ssh url and provide ssh keys in the
     ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly3-example.git
+    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main
@@ -70,7 +70,7 @@ orderly-runner:
     name: orderly.runner
     tag: main
   git:
-    url: https://github.com/reside-ic/orderly3-example.git
+    url: https://github.com/reside-ic/orderly2-example.git
   workers: 2
 
 ## If running a proxy directly, fill this section in.  Otherwise you

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "constellation==1.4.0",
+    "constellation==1.4.1",
     "docker",
     "docopt"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ path = "src/packit_deploy/__about__.py"
 
 [tool.hatch.envs.default]
 dependencies = [
-    "constellation==1.4.0",
+    "constellation",
     "coverage[toml]>=6.5",
     "docker",
     "docopt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "constellation==1.4.1",
+    "constellation==1.4.2",
     "docker",
     "docopt"
 ]

--- a/src/packit_deploy/config.py
+++ b/src/packit_deploy/config.py
@@ -58,6 +58,13 @@ class PackitConfig:
         else:
             self.packit_auth_enabled = False
 
+        if dat.get("orderly-runner"):
+            self.runner_ref = self.build_ref(dat, "orderly-runner", "image")
+            self.runner_workers = config.config_integer(dat, ["orderly-runner", "workers"])
+            self.runner_enabled = True
+        else:
+            self.runner_enabled = False
+
         self.containers = {
             "outpack-server": "outpack-server",
             "packit-db": "packit-db",
@@ -71,6 +78,9 @@ class PackitConfig:
             "packit-api": self.packit_api_ref,
             "packit": self.packit_ref,
         }
+        if self.runner_enabled:
+            self.images["orderly-runner"] = self.runner_ref
+            self.images["redis"] = constellation.ImageReference("library", "redis", "8.0")
 
         if dat.get("proxy"):
             self.proxy_enabled = config.config_boolean(dat, ["proxy", "enabled"], True)
@@ -126,6 +136,7 @@ class PackitConfig:
             self.volumes["proxy_logs"] = config.config_string(dat, ["volumes", "proxy_logs"])
 
     def build_ref(self, dat, section, subsection):
+        repo = config.config_string(dat, [section, subsection, "repo"], is_optional=True, default=self.repo)
         name = config.config_string(dat, [section, subsection, "name"])
         tag = config.config_string(dat, [section, subsection, "tag"])
         return constellation.ImageReference(self.repo, name, tag)

--- a/src/packit_deploy/config.py
+++ b/src/packit_deploy/config.py
@@ -84,6 +84,9 @@ class PackitConfig:
             self.containers["orderly-runner-api"] = "orderly-runner-api"
             self.containers["orderly-runner-worker"] = "orderly-runner-worker"
 
+            self.volumes["orderly_library"] = config.config_string(dat, ["volumes", "orderly_library"])
+            self.volumes["orderly_logs"] = config.config_string(dat, ["volumes", "orderly_logs"])
+
             self.images["orderly-runner"] = self.orderly_runner_ref
             self.images["redis"] = constellation.ImageReference("library", "redis", "8.0")
 

--- a/src/packit_deploy/config.py
+++ b/src/packit_deploy/config.py
@@ -73,7 +73,6 @@ class PackitConfig:
             "packit": self.packit_ref,
         }
 
-
         self.orderly_runner_enabled = "orderly-runner" in dat
         if self.orderly_runner_enabled:
             self.orderly_runner_ref = self.build_ref(dat, "orderly-runner", "image")
@@ -147,7 +146,6 @@ class PackitConfig:
             self.volumes["proxy_logs"] = config.config_string(dat, ["volumes", "proxy_logs"])
 
     def build_ref(self, dat, section, subsection):
-        repo = config.config_string(dat, [section, subsection, "repo"], is_optional=True, default=self.repo)
         name = config.config_string(dat, [section, subsection, "name"])
         tag = config.config_string(dat, [section, subsection, "tag"])
         return constellation.ImageReference(self.repo, name, tag)

--- a/src/packit_deploy/config.py
+++ b/src/packit_deploy/config.py
@@ -25,7 +25,6 @@ class PackitConfig:
         else:
             self.ssh = False
 
-        # Outpack!
         if "initial" in dat["outpack"]:
             self.outpack_source_url = config.config_string(dat, ["outpack", "initial", "url"])
         else:

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -115,7 +115,6 @@ def packit_api_container(cfg):
 
 
 def packit_api_get_env(cfg):
-    outpack = cfg.containers["outpack-server"]
     packit_db = cfg.containers["packit-db"]
     env = {
         "PACKIT_DB_URL": f"jdbc:postgresql://{cfg.container_prefix}-{packit_db}:5432/packit?stringtype=unspecified",
@@ -273,7 +272,7 @@ def orderly_runner_api_container(cfg):
     args = ["/data"]
     mounts = [
         constellation.ConstellationMount("orderly_library", "/library"),
-        constellation.ConstellationMount("orderly_logs", "/logs")
+        constellation.ConstellationMount("orderly_logs", "/logs"),
     ]
     return constellation.ConstellationContainer(
         name,
@@ -298,7 +297,7 @@ def orderly_runner_worker_container(cfg):
     args = ["/data"]
     mounts = [
         constellation.ConstellationMount("orderly_library", "/library"),
-        constellation.ConstellationMount("orderly_logs", "/logs")
+        constellation.ConstellationMount("orderly_logs", "/logs"),
     ]
     return constellation.ConstellationService(
         name,

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -271,12 +271,17 @@ def orderly_runner_api_container(cfg):
     }
     entrypoint = "/usr/local/bin/orderly.runner.server"
     args = ["/data"]
+    mounts = [
+        constellation.ConstellationMount("orderly_library", "/library"),
+        constellation.ConstellationMount("orderly_logs", "/logs")
+    ]
     return constellation.ConstellationContainer(
         name,
         image,
         environment=env,
         entrypoint=entrypoint,
         args=args,
+        mounts=mounts,
     )
 
 
@@ -291,6 +296,10 @@ def orderly_runner_worker_container(cfg):
     }
     entrypoint = "/usr/local/bin/orderly.runner.worker"
     args = ["/data"]
+    mounts = [
+        constellation.ConstellationMount("orderly_library", "/library"),
+        constellation.ConstellationMount("orderly_logs", "/logs")
+    ]
     return constellation.ConstellationService(
         name,
         image,
@@ -298,6 +307,7 @@ def orderly_runner_worker_container(cfg):
         environment=env,
         entrypoint=entrypoint,
         args=args,
+        mounts=mounts,
     )
 
 

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -150,11 +150,10 @@ def packit_api_get_env(cfg):
             )
     if cfg.orderly_runner_enabled:
         env["PACKIT_ORDERLY_RUNNER_URL"] = cfg.orderly_runner_api_url
-        # Why does packit need to know this?
         env["PACKIT_ORDERLY_RUNNER_REPOSITORY_URL"] = cfg.orderly_runner_git_url
-        # Is there a case where we would ever want this different to
-        # PACKIT_OUTPACK_SERVER_URL? Why does packit treat this
-        # differently?
+        # Mantra is going to tidy this up; it should always be the
+        # same as PACKIT_OUTPACK_SERVER_URL but differs because of
+        # automatic variable creation in the Kotlin framework.
         env["PACKIT_ORDERLY_RUNNER_LOCATION_URL"] = cfg.outpack_server_url
 
     return env

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -271,8 +271,8 @@ def orderly_runner_api_container(cfg):
     entrypoint = "/usr/local/bin/orderly.runner.server"
     args = ["/data"]
     mounts = [
-        constellation.ConstellationMount("orderly_library", "/library"),
-        constellation.ConstellationMount("orderly_logs", "/logs"),
+        constellation.ConstellationVolumeMount("orderly_library", "/library"),
+        constellation.ConstellationVolumeMount("orderly_logs", "/logs"),
     ]
     return constellation.ConstellationContainer(
         name,
@@ -296,8 +296,8 @@ def orderly_runner_worker_container(cfg):
     entrypoint = "/usr/local/bin/orderly.runner.worker"
     args = ["/data"]
     mounts = [
-        constellation.ConstellationMount("orderly_library", "/library"),
-        constellation.ConstellationMount("orderly_logs", "/logs"),
+        constellation.ConstellationVolumeMount("orderly_library", "/library"),
+        constellation.ConstellationVolumeMount("orderly_logs", "/logs"),
     ]
     return constellation.ConstellationService(
         name,

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -79,7 +79,7 @@ def outpack_ssh_configure(container, cfg):
 
 def outpack_init_clone(container, cfg):
     print("[orderly] Initialising orderly by cloning")
-    args = ["git", "clone", "-b", "update-orderly2", "--single-branch", cfg.outpack_source_url, "/outpack"]
+    args = ["git", "clone", cfg.outpack_source_url, "/outpack"]
 
     docker_util.exec_safely(container, args)
     # usually cloning a source repo will not ensure outpack is initialised
@@ -283,7 +283,6 @@ def orderly_runner_api_container(cfg):
     )
 
 
-# check the definition of the service container in orderly-web-deploy here.
 def orderly_runner_worker_container(cfg):
     name = cfg.containers["orderly-runner-worker"]
     image = str(cfg.images["orderly-runner"])

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -79,9 +79,7 @@ def outpack_ssh_configure(container, cfg):
 
 def outpack_init_clone(container, cfg):
     print("[orderly] Initialising orderly by cloning")
-    args = ["git", "clone",
-            "-b", "update-orderly2", "--single-branch",
-            cfg.outpack_source_url, "/outpack"]
+    args = ["git", "clone", "-b", "update-orderly2", "--single-branch", cfg.outpack_source_url, "/outpack"]
 
     docker_util.exec_safely(container, args)
     # usually cloning a source repo will not ensure outpack is initialised
@@ -255,15 +253,12 @@ def proxy_configure(container, cfg):
 def redis_container(cfg):
     name = cfg.containers["redis"]
     image = str(cfg.images["redis"])
-    return constellation.ConstellationContainer(
-        name, image, configure=redis_configure
-    )
+    return constellation.ConstellationContainer(name, image, configure=redis_configure)
 
 
-def redis_configure(container, cfg):
+def redis_configure(container, _cfg):
     print("[redis] Waiting for redis to come up")
-    docker_util.string_into_container(
-        WAIT_FOR_REDIS, container, "/wait_for_redis")
+    docker_util.string_into_container(WAIT_FOR_REDIS, container, "/wait_for_redis")
     docker_util.exec_safely(container, ["bash", "/wait_for_redis"])
 
 
@@ -277,7 +272,11 @@ def orderly_runner_api_container(cfg):
     entrypoint = "/usr/local/bin/orderly.runner.server"
     args = ["/data"]
     return constellation.ConstellationContainer(
-        name, image, environment=env, entrypoint=entrypoint, args=args,
+        name,
+        image,
+        environment=env,
+        entrypoint=entrypoint,
+        args=args,
     )
 
 
@@ -293,7 +292,12 @@ def orderly_runner_worker_container(cfg):
     entrypoint = "/usr/local/bin/orderly.runner.worker"
     args = ["/data"]
     return constellation.ConstellationService(
-        name, image, count, environment=env, entrypoint=entrypoint, args=args,
+        name,
+        image,
+        count,
+        environment=env,
+        entrypoint=entrypoint,
+        args=args,
     )
 
 

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -20,6 +20,11 @@ class PackitConstellation:
             proxy = proxy_container(cfg, packit_api, packit)
             containers.append(proxy)
 
+        if cfg.orderly_runner_enabled:
+            containers.append(redis_container(cfg))
+            containers.append(orderly_runner_api_container(cfg))
+            containers.append(orderly_runner_worker_container(cfg))
+
         self.cfg = cfg
         self.obj = constellation.Constellation(
             "packit", cfg.container_prefix, containers, cfg.network, cfg.volumes, data=cfg, vault_config=cfg.vault
@@ -74,7 +79,9 @@ def outpack_ssh_configure(container, cfg):
 
 def outpack_init_clone(container, cfg):
     print("[orderly] Initialising orderly by cloning")
-    args = ["git", "clone", cfg.outpack_source_url, "/outpack"]
+    args = ["git", "clone",
+            "-b", "update-orderly2", "--single-branch",
+            cfg.outpack_source_url, "/outpack"]
 
     docker_util.exec_safely(container, args)
     # usually cloning a source repo will not ensure outpack is initialised
@@ -116,7 +123,7 @@ def packit_api_get_env(cfg):
         "PACKIT_DB_URL": f"jdbc:postgresql://{cfg.container_prefix}-{packit_db}:5432/packit?stringtype=unspecified",
         "PACKIT_DB_USER": cfg.packit_db_user,
         "PACKIT_DB_PASSWORD": cfg.packit_db_password,
-        "PACKIT_OUTPACK_SERVER_URL": f"http://{cfg.container_prefix}-{outpack}:8000",
+        "PACKIT_OUTPACK_SERVER_URL": cfg.outpack_server_url,
         "PACKIT_AUTH_ENABLED": "true" if cfg.packit_auth_enabled else "false",
     }
     if hasattr(cfg, "brand_logo_name"):
@@ -144,6 +151,15 @@ def packit_api_get_env(cfg):
                     "PACKIT_AUTH_GITHUB_TEAM": cfg.packit_auth_github_api_team,
                 }
             )
+    if cfg.orderly_runner_enabled:
+        env["PACKIT_ORDERLY_RUNNER_URL"] = cfg.orderly_runner_api_url
+        # Why does packit need to know this?
+        env["PACKIT_ORDERLY_RUNNER_REPOSITORY_URL"] = cfg.orderly_runner_git_url
+        # Is there a case where we would ever want this different to
+        # PACKIT_OUTPACK_SERVER_URL? Why does packit treat this
+        # differently?
+        env["PACKIT_ORDERLY_RUNNER_LOCATION_URL"] = cfg.outpack_server_url
+
     return env
 
 
@@ -234,3 +250,80 @@ def proxy_configure(container, cfg):
         print("[proxy] Copying ssl certificate and key into proxy")
         docker_util.string_into_container(cfg.proxy_ssl_certificate, container, "/run/proxy/certificate.pem")
         docker_util.string_into_container(cfg.proxy_ssl_key, container, "/run/proxy/key.pem")
+
+
+def redis_container(cfg):
+    name = cfg.containers["redis"]
+    image = str(cfg.images["redis"])
+    return constellation.ConstellationContainer(
+        name, image, configure=redis_configure
+    )
+
+
+def redis_configure(container, cfg):
+    print("[redis] Waiting for redis to come up")
+    docker_util.string_into_container(
+        WAIT_FOR_REDIS, container, "/wait_for_redis")
+    docker_util.exec_safely(container, ["bash", "/wait_for_redis"])
+
+
+def orderly_runner_api_container(cfg):
+    name = cfg.containers["orderly-runner-api"]
+    image = str(cfg.images["orderly-runner"])
+    env = {
+        "REDIS_URL": cfg.redis_url,
+        "ORDERLY_RUNNER_QUEUE_ID": "orderly.runner.queue",
+    }
+    entrypoint = "/usr/local/bin/orderly.runner.server"
+    args = ["/data"]
+    return constellation.ConstellationContainer(
+        name, image, environment=env, entrypoint=entrypoint, args=args,
+    )
+
+
+# check the definition of the service container in orderly-web-deploy here.
+def orderly_runner_worker_container(cfg):
+    name = cfg.containers["orderly-runner-worker"]
+    image = str(cfg.images["orderly-runner"])
+    count = cfg.orderly_runner_workers
+    env = {
+        "REDIS_URL": cfg.redis_url,
+        "ORDERLY_RUNNER_QUEUE_ID": "orderly.runner.queue",
+    }
+    entrypoint = "/usr/local/bin/orderly.runner.worker"
+    args = ["/data"]
+    return constellation.ConstellationService(
+        name, image, count, environment=env, entrypoint=entrypoint, args=args,
+    )
+
+
+# Small script to wait for redis to come up
+WAIT_FOR_REDIS = """#!/usr/bin/env bash
+wait_for()
+{
+    echo "waiting up to $TIMEOUT seconds for redis"
+    start_ts=$(date +%s)
+    for i in $(seq $TIMEOUT); do
+        redis-cli -p 6379 ping | grep PONG
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echo "redis is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+        echo "...still waiting"
+    done
+    return $result
+}
+
+# The variable expansion below is 20s by default, or the argument provided
+# to this script
+TIMEOUT="${1:-20}"
+wait_for
+RESULT=$?
+if [[ $RESULT -ne 0 ]]; then
+  echo "redis did not become available in time"
+fi
+exit $RESULT
+"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -152,11 +152,11 @@ def test_workers_can_be_enabled():
     cfg = PackitConfig("config/complete")
     assert cfg.images
 
-    assert cfg.runner_enabled
-    assert cfg.runner_ref.repo == "mrcide"
-    assert cfg.runner_ref.name == "orderly.runner"
-    assert cfg.runner_ref.tag == "main"
-    assert cfg.runner_workers == 1
+    assert cfg.orderly_runner_enabled
+    assert cfg.orderly_runner_ref.repo == "mrcide"
+    assert cfg.orderly_runner_ref.name == "orderly.runner"
+    assert cfg.orderly_runner_ref.tag == "main"
+    assert cfg.orderly_runner_workers == 1
 
     assert len(cfg.images) == 7
     assert str(cfg.images["orderly-runner"]) == "mrcide/orderly.runner:main"
@@ -165,4 +165,4 @@ def test_workers_can_be_enabled():
 
 def test_workers_can_be_omitted():
     cfg = PackitConfig("config/noproxy")
-    assert not cfg.runner_enabled
+    assert not cfg.orderly_runner_enabled

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,7 +59,7 @@ def test_config_proxy():
 
 def test_outpack_initial_source():
     cfg = PackitConfig("config/complete")
-    assert cfg.outpack_source_url == "https://github.com/reside-ic/orderly3-example.git"
+    assert cfg.outpack_source_url == "https://github.com/reside-ic/orderly2-example.git"
 
     cfg = PackitConfig("config/nodemo")
     assert cfg.outpack_source_url is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,3 +146,23 @@ def test_custom_branding_with_complete_branding_config():
     assert cfg.brand_accent_foreground_light == "hsl(123 100% 50%)"
     assert cfg.brand_accent_dark == "hsl(30 100% 50%)"
     assert cfg.brand_accent_foreground_dark == "hsl(322, 50%, 87%)"
+
+
+def test_workers_can_be_enabled():
+    cfg = PackitConfig("config/complete")
+    assert cfg.images
+
+    assert cfg.runner_enabled
+    assert cfg.runner_ref.repo == "mrcide"
+    assert cfg.runner_ref.name == "orderly.runner"
+    assert cfg.runner_ref.tag == "main"
+    assert cfg.runner_workers == 1
+
+    assert len(cfg.images) == 7
+    assert str(cfg.images["orderly-runner"]) == "mrcide/orderly.runner:main"
+    assert str(cfg.images["redis"]) == "library/redis:8.0"
+
+
+def test_workers_can_be_omitted():
+    cfg = PackitConfig("config/noproxy")
+    assert not cfg.runner_enabled

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -213,18 +213,12 @@ def test_deploy_with_runner_support():
         cfg = PackitConfig(path)
         api = cfg.get_container("packit-api")
 
+        assert get_env_var(api, "PACKIT_ORDERLY_RUNNER_URL") == b"http://packit-orderly-runner-api:8001\n"
         assert (
-            get_env_var(api, "PACKIT_ORDERLY_RUNNER_URL") ==
-            b"http://packit-orderly-runner-api:8001\n"
+            get_env_var(api, "PACKIT_ORDERLY_RUNNER_REPOSITORY_URL")
+            == b"https://github.com/reside-ic/orderly2-example.git\n"
         )
-        assert (
-            get_env_var(api, "PACKIT_ORDERLY_RUNNER_REPOSITORY_URL") ==
-            b"https://github.com/reside-ic/orderly2-example.git\n"
-        )
-        assert (
-            get_env_var(api, "PACKIT_ORDERLY_RUNNER_LOCATION_URL") ==
-            get_env_var(api, "PACKIT_OUTPACK_SERVER_URL")
-        )
+        assert get_env_var(api, "PACKIT_ORDERLY_RUNNER_LOCATION_URL") == get_env_var(api, "PACKIT_OUTPACK_SERVER_URL")
     finally:
         stop_packit(path)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -199,6 +199,36 @@ def test_custom_branding_end_to_end():
         stop_packit(path)
 
 
+# Very basic test for now, just checking that everything appears:
+def test_deploy_with_runner_support():
+    path = "config/runner"
+    try:
+        cli.main(["start", path])
+        cl = docker.client.from_env()
+        containers = cl.containers.list()
+
+        prefix = "packit-orderly-runner-worker"
+        assert sum(x.name.startswith(prefix) for x in containers) == 2
+
+        cfg = PackitConfig(path)
+        api = cfg.get_container("packit-api")
+
+        assert (
+            get_env_var(api, "PACKIT_ORDERLY_RUNNER_URL") ==
+            b"http://packit-orderly-runner-api:8001\n"
+        )
+        assert (
+            get_env_var(api, "PACKIT_ORDERLY_RUNNER_REPOSITORY_URL") ==
+            b"https://github.com/reside-ic/orderly2-example.git\n"
+        )
+        assert (
+            get_env_var(api, "PACKIT_ORDERLY_RUNNER_LOCATION_URL") ==
+            get_env_var(api, "PACKIT_OUTPACK_SERVER_URL")
+        )
+    finally:
+        stop_packit(path)
+
+
 def test_vault():
     path = "config/complete"
     try:


### PR DESCRIPTION
This sets up the core bits to allow packit-deploy to deploy a runner-enabled instance of packit.  Following mantra's suggestion this PR follows the run-dependencies script in the packit sources - many of the previously painful bits are now handled automatically by the set up.

Things not done, which will come in later PRs:

* support for cloning private repos. I'll do this in a follow-on PR that generally sorts out some of the mess around cloning repos (we don't, for example, need an outpack clone anymore but we have one).
* persist the packit db
* set up an image for montagu that pulls in the required packages on top of the runner. Or tweak things to allow use of the (early-days) support for a library volume
* drop packit (but not the migration) from the montagu configurations, so that we can pull things up from here.
* add a configuration into montagu-config that will use packit-deploy with compatible names for everything

Testing locally:

```
hatch run packit start config/runner
./scripts/create-super-user
```

then go to https://localhost/runner where the app is running and log in with `resideUser@resideAdmin.ic.ac.uk` / `password`.

On the "Runner" page, refresh git (recycle button), select `main`, select `parameters` and see that the parameters form is correctly populated.  Add values for `a` and `c` (absolutely anything) and hit `Run`. The report should run almost immediately

Tear down with

```
hatch run packit stop --kill --volumes config/runner
```