### PR TITLE
Drop initial repo

### DIFF
--- a/config/basicauth/packit.yml
+++ b/config/basicauth/packit.yml
@@ -27,11 +27,6 @@ volumes:
   proxy_logs: packit_proxy_logs
 
 outpack:
-  ## Initialise an outpack directory by cloning from github
-  initial:
-    ##  If using a private repo, then use an ssh url and provide ssh keys in the
-    ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/basicauthcustombrand/packit.yml
+++ b/config/basicauthcustombrand/packit.yml
@@ -27,11 +27,6 @@ volumes:
   proxy_logs: packit_proxy_logs
 
 outpack:
-  ## Initialise an outpack directory by cloning from github
-  initial:
-    ##  If using a private repo, then use an ssh url and provide ssh keys in the
-    ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly3-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -28,19 +28,7 @@ volumes:
   orderly_library: orderly_library
   orderly_logs: orderly_logs
 
-## Path to ssh key for interacting with git. You
-## might use a github deploy key here. For completeness both the
-## public and private parts of the keypair are listed.
-ssh:
-  public: VAULT:secret/ssh:public
-  private: VAULT:secret/ssh:private
-
 outpack:
-  ## Initialise an outpack directory by cloning from github
-  initial:
-    ##  If using a private repo, then use an ssh url and provide ssh keys in the
-    ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/githubauth/packit.yml
+++ b/config/githubauth/packit.yml
@@ -27,11 +27,6 @@ volumes:
   proxy_logs: packit_proxy_logs
 
 outpack:
-  ## Initialise an outpack directory by cloning from github
-  initial:
-    ##  If using a private repo, then use an ssh url and provide ssh keys in the
-    ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/config/runner/packit.yml
+++ b/config/runner/packit.yml
@@ -29,11 +29,6 @@ volumes:
   orderly_logs: orderly_logs
 
 outpack:
-  ## Initialise an outpack directory by cloning from github
-  initial:
-    ##  If using a private repo, then use an ssh url and provide ssh keys in the
-    ## "ssh" section above.
-    url: https://github.com/reside-ic/orderly2-example.git
   server:
     name: outpack_server
     tag: main

--- a/src/packit_deploy/config.py
+++ b/src/packit_deploy/config.py
@@ -18,18 +18,6 @@ class PackitConfig:
         self.container_prefix = config.config_string(dat, ["container_prefix"])
         self.repo = config.config_string(dat, ["repo"])
 
-        if "ssh" in dat:
-            self.ssh_public = config.config_string(dat, ["ssh", "public"])
-            self.ssh_private = config.config_string(dat, ["ssh", "private"])
-            self.ssh = True
-        else:
-            self.ssh = False
-
-        if "initial" in dat["outpack"]:
-            self.outpack_source_url = config.config_string(dat, ["outpack", "initial", "url"])
-        else:
-            self.outpack_source_url = None
-
         self.outpack_ref = self.build_ref(dat, "outpack", "server")
         self.packit_api_ref = self.build_ref(dat, "packit", "api")
         self.packit_ref = self.build_ref(dat, "packit", "app")

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -55,35 +55,7 @@ def outpack_server_container(cfg):
 
 
 def outpack_server_configure(container, cfg):
-    if cfg.ssh:
-        outpack_ssh_configure(container, cfg)
-    if cfg.outpack_source_url is not None:
-        if outpack_is_initialised(container):
-            print("[outpack] outpack volume already contains data - not initialising")
-        else:
-            outpack_init_clone(container, cfg)
-
-
-def outpack_ssh_configure(container, cfg):
-    print("[outpack] Configuring ssh")
-    path_private = "/root/.ssh/id_rsa"
-    path_public = "/root/.ssh/id_rsa.pub"
-    path_known_hosts = "/root/.ssh/known_hosts"
-    docker_util.exec_safely(container, ["mkdir", "-p", "/root/.ssh"])
-    docker_util.string_into_container(cfg.ssh_private, container, path_private)
-    docker_util.string_into_container(cfg.ssh_public, container, path_public)
-    docker_util.exec_safely(container, ["chmod", "600", path_private])
-    hosts = docker_util.exec_safely(container, ["ssh-keyscan", "github.com"])
-    docker_util.string_into_container(hosts[1].decode("UTF-8"), container, path_known_hosts)
-
-
-def outpack_init_clone(container, cfg):
-    print("[orderly] Initialising orderly by cloning")
-    args = ["git", "clone", cfg.outpack_source_url, "/outpack"]
-
-    docker_util.exec_safely(container, args)
-    # usually cloning a source repo will not ensure outpack is initialised
-    # so here, check that outpack config exists, and if not, initialise
+    print("[outpack] Initialising outpack repository")
     if not outpack_is_initialised(container):
         image = str(cfg.outpack_ref)
         mounts = [docker.types.Mount("/outpack", cfg.volumes["outpack"])]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,6 @@ def test_config_no_proxy():
     assert str(cfg.images["packit-db"]) == "mrcide/packit-db:main"
     assert str(cfg.images["packit-api"]) == "mrcide/packit-api:main"
 
-    assert cfg.outpack_source_url is not None
     assert cfg.proxy_enabled is False
     assert cfg.protect_data is False
 
@@ -53,24 +52,6 @@ def test_config_proxy():
     assert not cfg.proxy_ssl_self_signed
     assert cfg.proxy_ssl_certificate == "VAULT:secret/cert:value"
     assert cfg.proxy_ssl_key == "VAULT:secret/key:value"
-
-
-def test_outpack_initial_source():
-    cfg = PackitConfig("config/complete")
-    assert cfg.outpack_source_url == "https://github.com/reside-ic/orderly2-example.git"
-
-    cfg = PackitConfig("config/nodemo")
-    assert cfg.outpack_source_url is None
-
-
-def test_ssh():
-    cfg = PackitConfig("config/complete")
-    assert cfg.ssh_public == "VAULT:secret/ssh:public"
-    assert cfg.ssh_private == "VAULT:secret/ssh:private"
-    assert cfg.ssh
-
-    cfg = PackitConfig("config/novault")
-    assert not cfg.ssh
 
 
 def test_github_auth():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -241,23 +241,6 @@ def test_vault():
         stop_packit(path)
 
 
-def test_ssh():
-    path = "config/complete"
-    try:
-        with vault_dev.Server() as s:
-            url = f"http://localhost:{s.port}"
-            cfg = PackitConfig(path, options={"vault": {"addr": url, "auth": {"args": {"token": s.token}}}})
-            write_secrets_to_vault(cfg)
-
-            cli.main(["start", path, f"--option=vault.addr={url}", f"--option=vault.auth.args.token={s.token}"])
-
-            outpack_server = cfg.get_container("outpack-server")
-            pub_key = docker_util.string_from_container(outpack_server, "/root/.ssh/id_rsa.pub")
-            assert pub_key == "publ1c"
-    finally:
-        stop_packit(path)
-
-
 def stop_packit(path):
     with mock.patch("src.packit_deploy.cli.prompt_yes_no") as prompt:
         prompt.return_value = True


### PR DESCRIPTION
This PR drops the now-unused support for the outpack initial repo and ssh keys.

The failing docker build will go away in time, and has nothing to do with code changes here.

The next ones will start introducing repositories for the runner, private keys, persistent db volume for packit etc