### PR TITLE
Revert references to mrc-6035-custom-branding back to main

### DIFF
--- a/config/basicauth/packit.yml
+++ b/config/basicauth/packit.yml
@@ -41,10 +41,10 @@ outpack:
 packit:
   api:
     name: packit-api
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   app:
     name: packit
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   db:
     name: packit-db
     tag: main

--- a/config/basicauthcustombrand/packit.yml
+++ b/config/basicauthcustombrand/packit.yml
@@ -42,10 +42,10 @@ outpack:
 packit:
   api:
     name: packit-api
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   app:
     name: packit
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   db:
     name: packit-db
     tag: main

--- a/config/complete/packit.yml
+++ b/config/complete/packit.yml
@@ -51,10 +51,10 @@ outpack:
 packit:
   api:
     name: packit-api
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   app:
     name: packit
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   db:
     name: packit-db
     tag: main

--- a/config/githubauth/packit.yml
+++ b/config/githubauth/packit.yml
@@ -42,10 +42,10 @@ outpack:
 packit:
   api:
     name: packit-api
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   app:
     name: packit
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   db:
     name: packit-db
     tag: main

--- a/config/nodemo/packit.yml
+++ b/config/nodemo/packit.yml
@@ -37,10 +37,10 @@ outpack:
 packit:
   api:
     name: packit-api
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   app:
     name: packit
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   db:
     name: packit-db
     tag: main

--- a/config/noproxy/packit.yml
+++ b/config/noproxy/packit.yml
@@ -35,10 +35,10 @@ outpack:
 packit:
   api:
     name: packit-api
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   app:
     name: packit
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   db:
     name: packit-db
     tag: main

--- a/config/novault/packit.yml
+++ b/config/novault/packit.yml
@@ -39,10 +39,10 @@ outpack:
 packit:
   api:
     name: packit-api
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   app:
     name: packit
-    tag: mrc-6035-custom-branding # revert to main after mrc-6035-custom-branding is merged
+    tag: main
   db:
     name: packit-db
     tag: main

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,11 +20,9 @@ def test_config_no_proxy():
 
     assert len(cfg.images) == 4
     assert str(cfg.images["outpack-server"]) == "mrcide/outpack_server:main"
-    # revert to main after mrc-6035-custom-branding is merged
-    assert str(cfg.images["packit"]) == "mrcide/packit:mrc-6035-custom-branding"
+    assert str(cfg.images["packit"]) == "mrcide/packit:main"
     assert str(cfg.images["packit-db"]) == "mrcide/packit-db:main"
-    # revert to main after mrc-6035-custom-branding is merged
-    assert str(cfg.images["packit-api"]) == "mrcide/packit-api:mrc-6035-custom-branding"
+    assert str(cfg.images["packit-api"]) == "mrcide/packit-api:main"
 
     assert cfg.outpack_source_url is not None
     assert cfg.proxy_enabled is False


### PR DESCRIPTION
At time of creating this PR, the CI is still running on the `main` branch of `mrc-ide/packit`, so it won't have pushed its latest docker image yet, so the CI here might fail temporarily