### PR TITLE
Update README for GHCR login

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The following example configurations are included under `/config`:
 ## Running locally
 
 You can bring up most of the configurations above for local testing (except for `complete` which includes non-existant vault secrets and `noproxy` which will not actually expose anything to interact with).  You will need access to the vault to run the `githubauth` configuration, which requires secrets for the github oauth2 client app
-details.
+details. You will also need to [log into GitHub Container Registry]([url](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)) using a GitHub personal access token (PAT) that has the following permissions: `write:packages`, `read:org`.
 
 For example, to bring up the `basicauth` configuration, you can run:
 


### PR DESCRIPTION
still not sure which exact permission set let it start working, because once i started removing permissions from the token, it continued to work (even after i deleted the token, implying something somewhere was cacheing my permissions, or i was no longer needing to pull from GHCR or something)