### PR TITLE
Make the orderly library volume read-only in orderly.runner workers

### DIFF
--- a/src/packit_deploy/__about__.py
+++ b/src/packit_deploy/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Alex Hill <alex.hill@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -356,7 +356,7 @@ def orderly_runner_worker_containers(runner: config.OrderlyRunner):
     entrypoint = "/usr/local/bin/orderly.runner.worker"
     args = ["/data"]
     mounts = [
-        constellation.ConstellationVolumeMount("orderly_library", "/library"),
+        constellation.ConstellationVolumeMount("orderly_library", "/library", read_only=True),
         constellation.ConstellationVolumeMount("orderly_logs", "/logs"),
     ]
     return constellation.ConstellationService(


### PR DESCRIPTION
This is to prevent jobs that run on the worker from having any possibility of updating the global/shared library of R packages.

To test this out:

```sh
packit configure config/runner
packit start --pull
docker inspect packit-orderly-runner-api
# observe that the 'Mounts' config lists orderly_library as "RW": true
docker inspect packit-orderly-runner-worker-<hash>
# observe that the 'Mounts' config lists orderly_library as "RW": false
```

