### PR TITLE
Make main branch pass CI workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Set up QEMU

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The following example configurations are included under `/config`:
 
 ## Running locally
 
-First, you need to [be logged into GitHub Container Registry]([url](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)) using a GitHub personal access token (PAT) that has the `read:packages` permission.
+First, you need to [be logged into GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic) using a GitHub personal access token (PAT) that has the `read:packages` permission.
 
 You can bring up most of the configurations above for local testing (except for `complete` which includes non-existant vault secrets and `noproxy` which will not actually expose anything to interact with). You will need access to the vault to run the `githubauth` configuration, which requires secrets for the github oauth2 client app details.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "packit-deploy"
 dynamic = ["version"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,11 +16,11 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/src/packit_deploy/cli.py
+++ b/src/packit_deploy/cli.py
@@ -80,12 +80,10 @@ def _verify_data_loss(protect_data):
         err = "Cannot remove volumes with this configuration"
         raise Exception(err)
     else:
-        print(
-            """WARNING! PROBABLE IRREVERSIBLE DATA LOSS!
+        print("""WARNING! PROBABLE IRREVERSIBLE DATA LOSS!
 You are about to delete the data volumes. This action cannot be undone
 and will result in the irreversible loss of *all* data associated with
-the application. This includes all databases, packet data etc."""
-        )
+the application. This includes all databases, packet data etc.""")
     if not _prompt_yes_no():
         msg = "Not continuing"
         raise Exception(msg)

--- a/src/packit_deploy/config.py
+++ b/src/packit_deploy/config.py
@@ -9,7 +9,7 @@ from constellation.acme import AcmeBuddyConfig
 from constellation.vault import VaultConfig
 
 
-def config_path(dat, key: list[str], *, root: str, is_optional: bool = False) -> Optional[Path]:
+def config_path(dat, key: list[str], *, root: str, is_optional: bool = False) -> Path | None:
     """
     Parse the path to an external asset.
 
@@ -52,7 +52,7 @@ APP_HTML_ROOT = "/usr/share/nginx/html"  # from Packit app Dockerfile
 class Context:
     root: str
     repo: str
-    instance: Optional[str]
+    instance: str | None
 
     def container_name(self, name: str) -> str:
         if self.instance is None:
@@ -83,13 +83,13 @@ class Theme:
 
 @dataclass
 class Branding:
-    name: Optional[str]
-    logo: Optional[Path]
-    logo_link: Optional[str]
-    logo_alt_text: Optional[str]
-    favicon: Optional[Path]
-    theme_light: Optional[Theme]
-    theme_dark: Optional[Theme]
+    name: str | None
+    logo: Path | None
+    logo_link: str | None
+    logo_alt_text: str | None
+    favicon: Path | None
+    theme_light: Theme | None
+    theme_dark: Theme | None
 
     @classmethod
     def from_data(cls, dat, key: list[str], *, ctx: Context) -> "Branding":
@@ -161,7 +161,7 @@ class PackitAuth:
     VALID_AUTH_METHODS = frozenset(("github", "basic", "preauth"))
 
     method: str
-    github: Optional[PackitAuthGithub]
+    github: PackitAuthGithub | None
     expiry_days: int
     jwt_secret: str
 
@@ -203,9 +203,9 @@ class PackitAPI:
     management_port: int
     base_url: str
     cors_allowed_origins: str
-    auth: Optional[PackitAuth]
-    runner_git_url: Optional[str]
-    runner_git_ssh_key: Optional[str]
+    auth: PackitAuth | None
+    runner_git_url: str | None
+    runner_git_ssh_key: str | None
     default_roles: str
 
     @classmethod
@@ -309,12 +309,12 @@ class SSL:
 class Proxy:
     container_name: ClassVar[str] = "proxy"
 
-    image: Union[BuildSpec, constellation.ImageReference]
+    image: BuildSpec | constellation.ImageReference
     hostname: str
     port_http: int
     port_https: int
     # port at which proxy will provide api and outpack server metrics. Different from PackitAPI management_port!
-    port_metrics: Optional[int]
+    port_metrics: int | None
 
     @classmethod
     def from_data(cls, dat, key: list[str], *, ctx: Context) -> "Proxy":
@@ -356,7 +356,7 @@ class PackitInstance:
 
     # packit_db_backup is not really needed for much. It was mostly used as
     # scratch space for maintenance operations.
-    volume_id_packit_db_backup: Optional[str]
+    volume_id_packit_db_backup: str | None
 
     # This is the map from volume ID to volume name, for instance-specific
     # volumes. It gets merged with other instances later.
@@ -430,13 +430,13 @@ class PackitConfig:
     protect_data: bool
     vault: VaultConfig
 
-    orderly_runner: Optional[OrderlyRunner]
-    proxy: Optional[Proxy]
-    acme_config: Optional[AcmeBuddyConfig]
+    orderly_runner: OrderlyRunner | None
+    proxy: Proxy | None
+    acme_config: AcmeBuddyConfig | None
 
     # The map of instances we host, with the same as the key.
     # In cases where a single unnamed instance is hosted, the key is None.
-    instances: dict[Optional[str], PackitInstance]
+    instances: dict[str | None, PackitInstance]
 
     def __init__(self, path, extra=None, options=None) -> None:
         dat = config.read_yaml(f"{path}/packit.yml")

--- a/src/packit_deploy/packit_constellation.py
+++ b/src/packit_deploy/packit_constellation.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import constellation
 import jinja2
@@ -77,7 +76,7 @@ class PackitConstellation:
         self.obj.status()
 
 
-def instance_hostname(name: Optional[str], toplevel: str):
+def instance_hostname(name: str | None, toplevel: str):
     if name is not None:
         return f"{name}.{toplevel}"
     else:
@@ -113,7 +112,7 @@ def packit_db_configure(container, _cfg: PackitConfig):
 
 
 def packit_api_container(
-    instance: config.PackitInstance, runner: Optional[config.OrderlyRunner]
+    instance: config.PackitInstance, runner: config.OrderlyRunner | None
 ) -> ConstellationContainer:
     name = instance.packit_api.container_name
     return ConstellationContainer(
@@ -123,7 +122,7 @@ def packit_api_container(
     )
 
 
-def packit_api_get_env(instance: config.PackitInstance, runner: Optional[config.OrderlyRunner]) -> dict[str, str]:
+def packit_api_get_env(instance: config.PackitInstance, runner: config.OrderlyRunner | None) -> dict[str, str]:
     env: dict[str, str] = {
         "PACKIT_DB_URL": instance.packit_db.jdbc_url,
         "PACKIT_DB_USER": instance.packit_db.user,


### PR DESCRIPTION
The CI workflows were failing on main.

Problems included:
* We were testing python 3.9, but that is end-of-life, so removed it
* We were not testing python 3.14 yet, which is in use, so I added it
* Because the default python in github actions is now 3.14 (something NOT caused by the above changes, but preceding them), the linting was full of new errors. At least I hypothesise that was a part of why we saw lint failures on CI. So I had to install python 3.14 locally, remove the existing hatch environment with `hatch env remove lint`, and recreate hatch's 'lint' environment with 3.14 specifically with `HATCH_PYTHON=python3.14 hatch run lint:fmt`, to get my local situation in sync with the CI one.

It would be nice to know that `hatch run test` works for you locally.