### PR TITLE
Bump version from 0.1.7 to 0.1.8

### DIFF
--- a/src/packit_deploy/__about__.py
+++ b/src/packit_deploy/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Alex Hill <alex.hill@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.7"
+__version__ = "0.1.8"


### PR DESCRIPTION
I'm bumping this version without any code changes in order to be able to create a new release, so that I can test out the infra-scripts task that installs the deploy tool. (Currently on the dev instances packit-dev and uat the latest version is already installed, and I want to see whether updating the deploy tool using the infra-scripts task causes unexpected side effects e.g. stopped containers -- but it won't feel like a real test to me unless a new version of the tool is published to pypi, because otherwise the install command might just be a no-op.)